### PR TITLE
Fix bug of selection returning to the previous function

### DIFF
--- a/commands.rb
+++ b/commands.rb
@@ -1,28 +1,27 @@
-require_relative 'find_files'
 require_relative 'select_item'
 
 include FindCSV
 
-def do_action
+def perform_command
 
   puts "Type 'view' to see current to do list\nType 'add' to add new item to to do list\nType 'end' to copy items from the input file to the output file and exit the system"
 
-  action = gets.chomp.downcase
+  command = gets.chomp.downcase
 
-  if (action == 'view')
+  if (command == 'view')
     select_item()
-  elsif (action == 'add')
+  elsif (command == 'add')
     puts "Enter new to do item"
     new_item = gets.chomp
     system("echo #{new_item} >> #{@input}")
     show_input_file()
-    do_action()
-  elsif (action == 'end')
+    perform_command()
+  elsif (command == 'end')
     system("cat #{@input} > #{@output}")
     return
   else
     puts "You entered an invalid command"
-    do_action()
+    perform_command()
   end
 
 end

--- a/list1.csv
+++ b/list1.csv
@@ -1,7 +1,9 @@
 Walk the dogs [Incomplete]
 Feed the cats [Doing]
 Kiss the rats
-Call for grab
+Call for grab [Incomplete]
 Something something [Doing]
-Eat dinner
+Eat dinner [Incomplete]
 hello world
+testing123 [Doing]
+Cross the street [Complete]

--- a/list2.csv
+++ b/list2.csv
@@ -1,7 +1,9 @@
 Walk the dogs [Incomplete]
 Feed the cats [Doing]
 Kiss the rats
-Call for grab
+Call for grab [Incomplete]
 Something something [Doing]
-Eat dinner
+Eat dinner [Incomplete]
 hello world
+testing123 [Doing]
+Cross the street [Complete]

--- a/main.rb
+++ b/main.rb
@@ -1,7 +1,9 @@
-require_relative 'actions'
+require_relative 'commands'
+require_relative 'select_item'
 
 include FindCSV
 
 find_files('input')
 find_files('output')
-do_action()
+perform_command()
+puts "Goodbye"

--- a/select_item.rb
+++ b/select_item.rb
@@ -1,5 +1,5 @@
 require 'csv'
-require_relative 'actions'
+require_relative 'commands'
 require_relative 'statuses'
 
 include FindCSV
@@ -8,17 +8,18 @@ def select_item
 
   show_input_file()
 
-  puts "Select a valid item number from the todo list\nOr select 0 to return to the previous function"
+  puts "Select a valid item number from the todo list\nOr type 'back' to return to the previous function"
 
-  @selection = gets.chomp.to_i
+  selection = gets.chomp
+  @selection_number = selection.to_i
 
-  if(@selection > 0 && @selection <= CSV.read(@input).count)
-    print "#{@selection}. "
-    system("sed -n '#{@selection},#{@selection} p' #{@input}")
+  if(@selection_number > 0 && @selection_number <= CSV.read(@input).count)
+    print "#{@selection_number}. "
+    system("sed -n '#{@selection_number},#{@selection_number} p' #{@input}")
     assign_status()
     select_item()
-  elsif(@selection == 0)
-    do_action()
+  elsif(selection == 'back')
+    perform_command()
   else
     puts "Please input a valid Integer"
     select_item()

--- a/statuses.rb
+++ b/statuses.rb
@@ -1,4 +1,5 @@
 require_relative 'select_item'
+require_relative 'find_files'
 
 include FindCSV
 
@@ -15,16 +16,17 @@ def assign_status
     $status_array.each_with_index do |text, i|
       puts "#{i+1}. #{text}"
     end
-    puts "Or select 0 to return to the previous function"
+    puts "Or type 'back' to return to the previous function"
   end
 
   show_array()
 
-  status = gets.chomp.to_i
+  status = gets.chomp
+  status_number = status.to_i
 
-  if (status > 0 && status <= $status_array.size + 1 )
-    system("sed -i '' '#{@selection},#{@selection} s/$/ [#{$status_array[status-1].split.last.capitalize}]/' #{@input}")
-  elsif (status == 0)
+  if (status_number > 0 && status_number <= $status_array.size + 1 )
+    system("sed -i '' '#{@selection_number},#{@selection_number} s/$/ [#{$status_array[status_number-1].split.last.capitalize}]/' #{@input}")
+  elsif (status == 'back')
     select_item()
   else
     puts "ERROR: Invalid option"


### PR DESCRIPTION
When selecting a to do list item, users are prompted to key in either a valid number or '0' to return back to the previous function. However, when any letter is converted into a number, it automatically becomes 0 causing the program to return back regardless of whether a valid command is keyed in.

This PR will fix this bug by converting their input to a integer through a new variable called `selection_number`. At the same time, prompting users to key in 'back' instead of '0' to return to a previous function. An intended recursion will occur if the command is not valid. 

This PR will also change the file and action names of `actions.rb` and `do_action` to `commands.rb` and `perform_command`.

